### PR TITLE
makeAPIRequest wasn't using the serviceID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.10.7",
+  "version": "0.11.0",
   "author": "Carlos Justiniano",
   "description": "A library for building microservices - built on Redis",
   "keywords": [


### PR DESCRIPTION
 if it was provided in the message URL

For example: 

```
b8277c82699a83db4e965831e189c095@hello-service:[get]/v1/hello/greeting
```

was getting load balanced rather than being directed to the specific message instance.
