### PR TITLE
New DNS resolve for serverIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "author": "Carlos Justiniano",
   "contributors": [
     {
@@ -18,8 +18,8 @@
       "github": "artemkochnev",
       "email": "artemkochnev@gmail.com"
     }
-  ],  
-  "description": "A library for building microservices - built on Redis",
+  ],
+  "description": "Hydra is a NodeJS light-weight library for building distributed computing applications such as microservices",
   "keywords": [
     "flywheelsports",
     "hydra",


### PR DESCRIPTION
This allows for users to specify a DNS name inside the hydra config branch:

```
  "hydra": {
    "serviceName": "hydra-router",
    "serviceDescription": "Service Router",
    "serviceIP": "dockerhost",
    "servicePort": 5353,
```

This will also allow hydra-enabled services to run in docker containers started with the `--add-host` parameter:

```
docker run -d -p 5353:80 --add-host dockerhost:$HOST_IP --workdir=/usr/src/app -v ~/usr/local/etc/hydra-router:/usr/src/app/config --name hydra-router flywheelsports/fwsp-hydra-router:0.11.3'
```