### PR TITLE
Eric's patch for promise warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,15 +90,16 @@ class Hydra extends EventEmitter {
    * @param {object} config - configuration object containing hydra specific keys/values
    * @return {object} promise - resolves with this._init
    */
-  init(config) {
-    return new Promise((resolve, reject) => {
-      Promise.series(this.registeredPlugins, plugin => plugin.setConfig(config))
-        .then((...results) => {
-          resolve(this._init(config));
-        })
-        .catch(err => this._logMessage('error', err.toString()));
-    });
-  }
+   init(config) {
+     return new Promise((resolve, reject) => {
+       Promise.series(this.registeredPlugins, plugin => plugin.setConfig(config))
+         .then((...results) => {
+           return this._init(config);
+         })
+         .then(() => resolve())
+         .catch(err => this._logMessage('error', err.toString()));
+     });
+   }
 
   /**
    * @name _init


### PR DESCRIPTION
@emadum fix for the following promise warning:

```
(node:5771) Warning: a promise was created in a handler at /Users/cjustiniano/dev/flywheelsports/fwsp-hydra-router/node_modules/fwsp-hydra/index.js:96:24 but was not returned from it, see http://goo.gl/rRqMUw
```