### PR TITLE
deterministic service instance selection with retry logic 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "author": "Carlos Justiniano",
   "contributors": [
     {


### PR DESCRIPTION
PR to switch from random load balancing to a deterministic model where the service instance which has most recently reported presence status is favored. The premise is that instance which which have not recently reported presence are more likely to have experienced a fatal issue.

_makeAPIRequest now supports retries if a service endpoint returns an error. When that happens another service instance is immediately selected as a retry target.