### PR TITLE
fix for name-based serverIP

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,13 +137,13 @@ class Hydra extends EventEmitter {
 
           // if serviceIP field contains a name rather than a dotted IP address
           // then use DNS to resolve the name to an IP address.
-          if (this.config.serviceIP && this.config.serviceIP !== '' &&
-            net.isIP(this.config.serviceIP) === 0) {
+          if (this.config.serviceIP && this.config.serviceIP !== '' && net.isIP(this.config.serviceIP) === 0) {
             dns.lookup(this.config.serviceIP, (err, result) => {
               this.config.serviceIP = result;
+              this._updateInstanceData();
+              ready();
             });
-          }
-          if (!this.config.serviceIP || this.config.serviceIP === '') {
+          } else if (!this.config.serviceIP || this.config.serviceIP === '') {
             dns.lookup(require('os').hostname(), (err, address, fam) => {
               this.config.serviceIP = address;
               this._updateInstanceData();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": "Carlos Justiniano",
   "contributors": [
     {


### PR DESCRIPTION
When a DNS name was used in the config.serviceIP field hydra was allowing the promise to resolve before properly updating.  Thre premature promise resolve was causing the serviceIP to not be properly set on initialization. 