### PR TITLE
Hydra logging now uses msg field

### DIFF
--- a/index.js
+++ b/index.js
@@ -671,7 +671,7 @@ class Hydra extends EventEmitter {
       serviceName: this.serviceName || 'not a service',
       type,
       processID: process.pid,
-      message
+      msg: message
     };
 
     if (!suppressEmit) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "author": "Carlos Justiniano",
   "contributors": [
     {


### PR DESCRIPTION
This was done to match our ELK stack logging which uses `msg` rather than `message`.