### PR TITLE
experimental removal of prequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "author": "Carlos Justiniano",
   "contributors": [
     {
@@ -40,7 +40,6 @@
   "dependencies": {
     "bluebird": "3.5.0",
     "fwsp-jsutils": "1.0.9",
-    "fwsp-prequest": "1.1.2",
     "fwsp-redis-connection": "0.0.2",
     "fwsp-server-response": "2.2.3",
     "fwsp-umf-message": "0.4.3",


### PR DESCRIPTION
pRequest has an issue where it doesn't return the status code of its request. This makes it unusable by hydra-router and probably not a good idea elsewhere.  This PR removes the one place in hydra where pRequest was used.